### PR TITLE
adds together FragID parts in the same cell (reach) 

### DIFF
--- a/SFR_main_HWR.py
+++ b/SFR_main_HWR.py
@@ -42,6 +42,8 @@ COMIDdata.populate_routing(SFRdata, FragIDdata, LevelPathdata, CELLdata)
 
 COMIDdata.return_hydrosequence_comid()
 
+FragIDdata.return_cellnum_LevelPathID(LevelPathdata)
+
 LevelPathdata.return_cutoffs(FragIDdata, CELLdata, SFRdata)
 
 SFRops.reach_ordering(COMIDdata, FragIDdata, LevelPathdata)


### PR DESCRIPTION
makes effective properties (length, width, elev, slope) for reach from FragID parts within the same cell, but it doesn't break separate the parts if the cell is a confluence and two segments with the same levelpathID claim the same cell for a reach (should only happen for the end of the upstream segment and the beginning of the downstream segment).
