### PR TITLE
Change inequality for ibound when creating isfr array

### DIFF
--- a/sfrmaker/lines.py
+++ b/sfrmaker/lines.py
@@ -91,13 +91,14 @@ class Lines:
         """
         valid_units = {'feet': 'feet',
                        'foot': 'feet',
+                       'us-ft': 'feet',
                        'meters': 'meters',
-                       'metre': 'meters'}
+                       'meter': 'meters'}
         self._geometry_length_units = valid_units.get(self.crs.axis_info[0].unit_name)
         if self._geometry_length_units is None:
             print("Warning: No length units specified in CRS for input LineStrings "
-                  "or length units not recognized"
-                  "defaulting to meters.")
+                  "or length units not recognized. "
+                  "Defaulting to meters.")
             self._geometry_length_units = 'meters'
         return self._geometry_length_units
 

--- a/sfrmaker/lines.py
+++ b/sfrmaker/lines.py
@@ -803,7 +803,7 @@ class Lines:
             if model.version == 'mf6':
                 isfr = np.sum(model.dis.idomain.array == 1, axis=0) > 0
             else:
-                isfr = np.sum(model.bas6.ibound.array == 1, axis=0) > 0
+                isfr = np.sum(model.bas6.ibound.array > 0, axis=0) > 0
         if flopy and isinstance(grid, flopy.discretization.StructuredGrid):
             print('\nCreating grid class instance from flopy Grid instance...')
             ta = time.time()


### PR DESCRIPTION
Updated the inequality applied to ibound when creating the isfr array. For modflow 2005 (and nwt), a value of > 0 can be used to indicate a cell is active. This was leading to sfr reachs being removed in cells where ibound was > 1.

Other minor changes.