### PR TITLE
fix(line_id dtypes): cast line_ids and NHDPlus COMIDs explicitly to '…

### DIFF
--- a/sfrmaker/preprocessing.py
+++ b/sfrmaker/preprocessing.py
@@ -205,16 +205,16 @@ def cull_flowlines(NHDPlus_paths,
     # drop any entries without ID numbers
     # enforce integer dtype in ID numbers
     fl.dropna(subset=['COMID'], axis=0, inplace=True)
-    fl['COMID'] = fl.COMID.astype(int)
+    fl['COMID'] = fl.COMID.astype('int64')
     fl.index = fl['COMID']
     pfvaa.dropna(subset=['ComID'], axis=0, inplace=True)
-    pfvaa['ComID'] = pfvaa.ComID.astype(int)
+    pfvaa['ComID'] = pfvaa.ComID.astype('int64')
     pfvaa.index = pfvaa['ComID']
     pf.dropna(subset=['FROMCOMID'], axis=0, inplace=True)
-    pf['FROMCOMID'] = pf.FROMCOMID.astype(int)
+    pf['FROMCOMID'] = pf.FROMCOMID.astype('int64')
     pf.index = pf['FROMCOMID']
     elevslope.dropna(subset=['COMID'], axis=0, inplace=True)
-    elevslope['COMID'] = elevslope.COMID.astype(int)
+    elevslope['COMID'] = elevslope.COMID.astype('int64')
     elevslope.index = elevslope['COMID']
 
     original_comids = set(fl.index)
@@ -1634,7 +1634,7 @@ def swb_runoff_to_csv(swb_runoff_netcdf_output, nhdplus_catchments_file,
     
     # rasterize the catchments unto the NetCDF file grid
     features_list = list(zip(catchments['geometry'], 
-                             catchments[catchment_id_col].astype(int)))
+                             catchments[catchment_id_col].astype('int64')))
     rasterized = rasterio.features.rasterize(features_list, out_shape=(nrow, ncol), 
                                     transform=nc_trans)
     out_text_array = outfile.parent / 'nhdplus_catchments.dat'

--- a/sfrmaker/routing.py
+++ b/sfrmaker/routing.py
@@ -178,7 +178,7 @@ def make_graph(fromcomids, tocomids, one_to_many=True):
     if scalar_tocomids:
         tocomid_sets = [{int(v)} for v in tocomids]
     else:
-        tocomid_sets = [set(a.astype(int).tolist()) for a in map(np.array, tocomids)]
+        tocomid_sets = [set(a.astype('int64').tolist()) for a in map(np.array, tocomids)]
     tuples = zip(fromcomids, tocomid_sets)
     graph = defaultdict(set)
     for fromcomid, tocomid in tuples:

--- a/sfrmaker/sfrdata.py
+++ b/sfrmaker/sfrdata.py
@@ -110,7 +110,7 @@ class SFRData(DataPackage):
               'thts2', 'thti2', 'eps2', 'uhc2']
 
     dtypes = {'rno': int, 'node': int, 'k': int, 'i': int, 'j': int,
-              'iseg': int, 'ireach': int, 'outreach': int, 'line_id': int,
+              'iseg': int, 'ireach': int, 'outreach': int, 'line_id': 'int64',
               'per': int, 'nseg': int, 'icalc': int, 'outseg': int,
               'iupseg': int, 'iprior': int, 'nstrpts': int,
               'name': object, 'geometry': object}


### PR DESCRIPTION
…int64' instead of int. Apparently python's <int> uses a C long type internally, which is defined as 32 bit on 64-bit Windows. This causes problems with NHDPlus Hi-Res COMIDs, require 64-bits as integers.