### PR TITLE
fix(gis.py): Ensure valid geometries for intersection functions

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -4,6 +4,7 @@ Modules
 .. toctree::
 
    Flows Module <sfrmaker.flows>
+   GIS Module <sfrmaker.gis>
    Grid Module <sfrmaker.grid>
    Lines Module <sfrmaker.lines>
    MODFLOW-2005 to 6 Module <sfrmaker.mf5to6>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,9 +109,6 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
-import sphinx_rtd_theme
-
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -206,5 +203,6 @@ intersphinx_mapping = {
     'flopy': ('https://flopy.readthedocs.io/en/latest/', None),
     'rasterstats': ('https://pythonhosted.org/rasterstats/', None),
     'shapely': ('https://shapely.readthedocs.io/en/latest/', None),
-    'pyproj': ('http://pyproj4.github.io/pyproj/stable/', None)
+    'pyproj': ('http://pyproj4.github.io/pyproj/stable/', None),
+    'rtree': ('https://rtree.readthedocs.io/en/latest/', None)
 }

--- a/sfrmaker/gis.py
+++ b/sfrmaker/gis.py
@@ -50,7 +50,8 @@ def get_crs(prjfile=None, crs=None, **kwargs):
 
 
 def build_rtree_index(geom):
-    """Builds an rtree index. Useful for multiple intersections with same index.
+    """Builds an :class:`rtree.index.Index` (spatial index) object. 
+    Useful for multiple intersections with same index.
 
     Parameters
     ==========
@@ -99,16 +100,19 @@ def intersect_rtree(geom1, geom2, index=None):
     """Intersect features in geom1 with those in geom2. For each feature in geom2, return a list of
      the indices of the intersecting features in geom1.
 
-    Parameters:
+    Parameters
     ----------
     geom1 : list
         list of shapely geometry objects
     geom2 : list
         list of shapely geometry objects to be intersected with features in geom1
-    index :
-        use an index that has already been created for geom1
+    index : rtree spatial index
+        Option to use an r-tree spatial index that has already been created for geom1.
+        The :func:`sfrmaker.gis.build_rtree_index` function can be used to
+        create a spatial index for a list of shapely geometriy objects.
+        by default, None.
 
-    Returns:
+    Returns
     -------
     A list of the same length as geom2; containing for each feature in geom2,
     a list of indicies of intersecting geometries in geom1.
@@ -140,14 +144,14 @@ def intersect(geom1, geom2):
     """Same as intersect_rtree, except without spatial indexing. Fine for smaller datasets,
     but scales by 10^4 with the side of the problem domain.
 
-    Parameters:
+    Parameters
     ----------
     geom1 : list
         list of shapely geometry objects
     geom2 : list
         list of shapely geometry objects to be intersected with features in geom1
 
-    Returns:
+    Returns
     -------
     A list of the same length as geom2; containing for each feature in geom2,
     a list of indicies of intersecting geometries in geom1.


### PR DESCRIPTION
Employ shapely’s make_valid() for input geometries to intersect_rtree() and intersect() to prevent errors. Also purge code comments of geom2 being polygon geometries for both functions plus rename variable “poly” to “geom” when enumerating geom2 in intersect_rtree().

Fixes #169.