### PR TITLE
fix(routing.py::find_path): if the starting ID == the end ID, return …

### DIFF
--- a/sfrmaker/routing.py
+++ b/sfrmaker/routing.py
@@ -122,6 +122,8 @@ def find_path(graph, start, end='0', limit=None):
     if limit is None:
         limit = len(graph)
     path = [start]
+    if str(start) == str(end):
+        return path
     next_id = start
     for i in range(limit):
         next_id = graph[next_id]


### PR DESCRIPTION
…the end ID (which is the last ID in any other returned path), instead of raising an error.