### PR TITLE
changed bug-causing filter arg to bbox_filter in load_nhdplus_hr

### DIFF
--- a/sfrmaker/nhdplus_utils.py
+++ b/sfrmaker/nhdplus_utils.py
@@ -472,7 +472,7 @@ def load_nhdplus_hr(NHDPlusHR_paths, bbox_filter=None,
             - ``crs``: NHDPlus HR data are assumed to include valid projection information.
             - ``epsg`` (int): NHDPlus HR data are assumed to include valid projection information.
             - ``proj_str`` (str): NHDPlus HR data are assumed to include valid projection information.
-                - ``filter`` (tuble): use ``bbox_filter`` instead.
+            - ``filter`` (tuble): use ``bbox_filter`` instead.
 
     Returns
     ==========
@@ -505,7 +505,7 @@ def load_nhdplus_hr(NHDPlusHR_paths, bbox_filter=None,
     
     #  Read if using one HUC-4 FileGDP passed as str
     if isinstance(NHDPlusHR_paths, str) or isinstance(NHDPlusHR_paths, Path):
-        df = read_nhdplus_hr(NHDPlusHR_paths, filter = filter)
+        df = read_nhdplus_hr(NHDPlusHR_paths, bbox_filter=bbox_filter)
    
     #  Option to drop specified FCodes
     if drop_fcodes is not None:    

--- a/sfrmaker/nhdplus_utils.py
+++ b/sfrmaker/nhdplus_utils.py
@@ -453,7 +453,7 @@ def load_nhdplus_hr(NHDPlusHR_paths, bbox_filter=None,
         Subregion  file geodatabase (.gdb) to include, assuming the file structure 
         is the same as when downloaded from the USGS National Map Downloader tool 
         (v2.0) website (https://apps.nationalmap.gov/downloader/#/).
-    filter : tuple, str (filepath), shapely Polygon or GeoJSON polygon
+    bbox_filter : tuple, str (filepath), shapely Polygon or GeoJSON polygon
         Bounding box (tuple) or polygon feature of model stream network area.
         Shapefiles will be reprojected to the CRS of the flowlines; all other
         feature types must be supplied in same CRS as flowlines.
@@ -472,7 +472,7 @@ def load_nhdplus_hr(NHDPlusHR_paths, bbox_filter=None,
             - ``crs``: NHDPlus HR data are assumed to include valid projection information.
             - ``epsg`` (int): NHDPlus HR data are assumed to include valid projection information.
             - ``proj_str`` (str): NHDPlus HR data are assumed to include valid projection information.
-            - ``filter`` (tuble): use ``bbox_filter`` instead.
+            - ``filter`` (tuple): use ``bbox_filter`` instead.
 
     Returns
     ==========


### PR DESCRIPTION
I modified a single line in nhdplus_utils.py where the function load_nhdplus_hr() makes a call to the function read_nhdplus_hr() using the deprecated "filter" argument instead of the updated "bbox_filter" argument. This only causes a bug when NHDPlusHR_paths is provided as a string or path. When provided as a list, the call to read_nhdplus_hr() uses the updated bbox_filter arg.

I'm just getting my feet wet learning how to contribute to existing code repositories, and this seemed like a simple case to try it out. Hopefully the steps I followed from a rudimentary google search were sufficient, and this is more helpful than burdensome.