### PR TITLE
feat(add_observations): expose distance_threshold argument 

### DIFF
--- a/sfrmaker/observations.py
+++ b/sfrmaker/observations.py
@@ -27,7 +27,9 @@ def add_observations(sfrdata, data, flowline_routing=None,
                      line_id_column=None,
                      rno_column=None,
                      obstype_column=None,
-                     obsname_column='site_no'):
+                     obsname_column='site_no',
+                     site_location_distance_threshold=1000,
+                     ):
     """Add SFR observations to the observations DataFrame
     attribute of an sfrdata instance. Observations can
     by located on the SFR network by specifying reach number
@@ -76,7 +78,9 @@ def add_observations(sfrdata, data, flowline_routing=None,
         If obstype and obstype_column_in_data are none, the default of 'downstream-flow' will be used.
     obsname_column : str
         Column in data with unique identifier (e.g. site number or name) for observation sites.
-
+    site_location_distance_threshold : scalar
+        Only consider sites within this distance of a stream line-arc (only applies if x_location_column 
+        and y_location_column are being used to located the observations).
 
     Notes
     -----
@@ -118,7 +122,8 @@ def add_observations(sfrdata, data, flowline_routing=None,
                                 x_column_in_data=x_location_column,
                                 y_column_in_data=y_location_column,
                                 reach_id_col='rno',  # reach number column in reach_data
-                                site_number_col=obsname_column
+                                site_number_col=obsname_column,
+                                distance_threshold=site_location_distance_threshold
                                 )
             data[rno_column] = locs['rno']
 

--- a/sfrmaker/sfrdata.py
+++ b/sfrmaker/sfrdata.py
@@ -832,7 +832,8 @@ class SFRData(DataPackage):
                          rno_column=None,
                          obstype_column=None,
                          obsname_column='site_no',
-                         gage_starting_unit_number=250):
+                         gage_starting_unit_number=250,
+                         site_location_distance_threshold=1000):
         self.gage_starting_unit_number = gage_starting_unit_number
         added_obs = add_observations(self, data, flowline_routing=flowline_routing,
                                      obstype=obstype, sfrlines_shapefile=sfrlines_shapefile,
@@ -841,7 +842,9 @@ class SFRData(DataPackage):
                                      line_id_column=line_id_column,
                                      rno_column=rno_column,
                                      obstype_column=obstype_column,
-                                     obsname_column=obsname_column)
+                                     obsname_column=obsname_column,
+                                     site_location_distance_threshold=site_location_distance_threshold
+                                     )
 
         # replace any observations that area already in the observations table
         if isinstance(self._observations, pd.DataFrame):

--- a/sfrmaker/test/data/shellmound/shellmound_config.yml
+++ b/sfrmaker/test/data/shellmound/shellmound_config.yml
@@ -34,6 +34,7 @@ observations:  # see sfrmaker.observations.add_observations for arguments
   x_location_column: x  # observation locations, in CRS coordinates
   y_location_column: y
   obsname_column: site_no  # column for naming observations
+  site_location_distance_threshold: 1000
 options:
   one_reach_per_cell: True #  consolidate SFR reaches to one per i, j location
   add_outlets: 1000001  # add outlets at these line numbers


### PR DESCRIPTION
as site_location_distance_threshold so that it can be specified in add_observations() function (and in corresponding configuration file blocks for sfrmaker and modflow-setup)